### PR TITLE
Fix bug in chatContextMenu's run command

### DIFF
--- a/src/mods/chatContextMenu/index.js
+++ b/src/mods/chatContextMenu/index.js
@@ -102,11 +102,14 @@ export default {
 	name: 'Chat Context Menu',
 	description:
 		'Displays a menu when you click on a player, allowing you to whisper/party/friend/block them',
-	run: ({ registerOnPageClick }) => {
+	run: ({ registerOnPageClick, registerOnChatChange }) => {
 		createChatContextMenu();
 		chatContextMenu();
 
 		// When we click anywhere on the page outside of our chat context menu, we want to close the menu
 		registerOnPageClick(closeChatContextMenu);
+		
+		// Register event listeners for each name when a new chat message appears
+		registerOnChatChange(chatContextMenu);
 	},
 };


### PR DESCRIPTION
Click event listeners weren't being added to new chat messages onChatChange