### PR TITLE
Update friend/block list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hordesuimod",
-	"version": "1.0.1",
+	"version": "1.0.3",
 	"description": "Userscript mod for hordes.io",
 	"main": "src/compile.js",
 	"scripts": {

--- a/src/mods/blockedPlayerSettings/index.js
+++ b/src/mods/blockedPlayerSettings/index.js
@@ -3,8 +3,6 @@ import { makeElement } from '../../utils/misc';
 import * as player from '../../utils/player';
 
 function blockedPlayerSettings() {
-	const state = getState();
-
 	const $settings = document.querySelector('.divide:not(.js-settings-initd)');
 	if (!$settings) {
 		return;
@@ -21,51 +19,57 @@ function blockedPlayerSettings() {
 	);
 
 	// Upon click, we display our custom settings window UI
-	document.querySelector('.js-blocked-players').addEventListener('click', () => {
-		let blockedPlayersHTML = '';
-		Object.keys(state.blockList)
-			.sort()
-			.forEach(blockedName => {
-				blockedPlayersHTML += `
-                <div data-player-name="${blockedName}">${blockedName}</div>
-                <div class="btn orange js-unblock-player" data-player-name="${blockedName}">Unblock player</div>
-            `;
-			});
+	document.querySelector('.js-blocked-players').addEventListener('click', showBlockedList);
+}
 
-		const customSettingsHTML = `
-            <h3 class="textprimary">Blocked players</h3>
-            <div class="settings uimod-settings">${blockedPlayersHTML}</div>
-            <p></p>
-            <div class="btn purp js-close-custom-settings">Close</div>
-        `;
+function showBlockedList() {
+	const state = getState();
 
-		const $customSettings = makeElement({
-			element: 'div',
-			class: 'menu panel-black js-custom-settings uimod-custom-window',
-			content: customSettingsHTML,
+	let blockedPlayersHTML = '';
+	Object.keys(state.blockList)
+		.sort()
+		.forEach(blockedName => {
+			blockedPlayersHTML += `
+			<div data-player-name="${blockedName}">${blockedName}</div>
+			<div class="btn orange js-unblock-player" data-player-name="${blockedName}">Unblock player</div>
+		`;
 		});
-		document.body.appendChild($customSettings);
 
-		// Wire up all the unblock buttons
-		Array.from(document.querySelectorAll('.js-unblock-player')).forEach($button => {
-			$button.addEventListener('click', clickEvent => {
-				const name = clickEvent.target.getAttribute('data-player-name');
-				player.unblockPlayer(name);
+	const customSettingsHTML = `
+		<h3 class="textprimary">Blocked players</h3>
+		<div class="settings uimod-settings">${blockedPlayersHTML}</div>
+		<p></p>
+		<div class="btn purp js-close-custom-settings">Close</div>
+	`;
 
-				// Remove the blocked player from the list
-				Array.from(
-					document.querySelectorAll(`.js-custom-settings [data-player-name="${name}"]`),
-				).forEach($element => {
-					$element.parentNode.removeChild($element);
-				});
+	const $customSettings = makeElement({
+		element: 'div',
+		class: 'menu panel-black js-custom-settings uimod-custom-window js-blocked-list',
+		content: customSettingsHTML,
+	});
+	document.body.appendChild($customSettings);
+
+	// Wire up all the unblock buttons
+	Array.from(document.querySelectorAll('.js-unblock-player')).forEach($button => {
+		$button.addEventListener('click', clickEvent => {
+			const name = clickEvent.target.getAttribute('data-player-name');
+			player.unblockPlayer(name);
+
+			// Remove the blocked player from the list
+			Array.from(
+				document.querySelectorAll(`.js-blocked-list [data-player-name="${name}"]`),
+			).forEach($element => {
+				$element.parentNode.removeChild($element);
 			});
-		});
-		// And the close button for our custom UI
-		document.querySelector('.js-close-custom-settings').addEventListener('click', () => {
-			const $customSettingsWindow = document.querySelector('.js-custom-settings');
-			$customSettingsWindow.parentNode.removeChild($customSettingsWindow);
 		});
 	});
+	// And the close button for our custom UI
+	document.querySelector('.js-close-custom-settings').addEventListener('click', hideBlockedList);
+}
+
+function hideBlockedList() {
+	const $customSettingsWindow = document.querySelector('.js-blocked-list');
+	$customSettingsWindow.parentNode.removeChild($customSettingsWindow);
 }
 
 export default {
@@ -78,3 +82,5 @@ export default {
 		registerOnDomChange(blockedPlayerSettings);
 	},
 };
+
+export { showBlockedList, hideBlockedList };

--- a/src/mods/friendsList/index.js
+++ b/src/mods/friendsList/index.js
@@ -4,8 +4,6 @@ import { makeElement } from '../../utils/misc';
 
 // The F icon and the UI that appears when you click it
 function customFriendsList() {
-	const state = getState();
-
 	var friendsIconElement = makeElement({
 		element: 'div',
 		class: 'btn border black js-friends-list-icon',
@@ -16,78 +14,86 @@ function customFriendsList() {
 	$elixirIcon.parentNode.insertBefore(friendsIconElement, $elixirIcon.nextSibling);
 
 	// Create the friends list UI
-	document.querySelector('.js-friends-list-icon').addEventListener('click', () => {
-		if (document.querySelector('.js-friends-list')) {
-			// Don't open the friends list twice.
-			return;
-		}
-		let friendsListHTML = '';
-		Object.keys(state.friendsList)
-			.sort()
-			.forEach(friendName => {
-				friendsListHTML += `
-                <div data-player-name="${friendName}">${friendName}</div>
-                <div class="btn blue js-whisper-player" data-player-name="${friendName}">Whisper</div>
-                <div class="btn blue js-party-player" data-player-name="${friendName}">Party invite</div>
-                <div class="btn orange js-unfriend-player" data-player-name="${friendName}">X</div>
-                <input type="text" class="js-friend-note" data-player-name="${friendName}" value="${state
-					.friendNotes[friendName] || ''}"></input>
-            `;
-			});
+	document.querySelector('.js-friends-list-icon').addEventListener('click', showFriendsList);
+}
 
-		const customFriendsWindowHTML = `
-            <h3 class="textprimary">Friends list</h3>
-            <div class="uimod-friends">${friendsListHTML}</div>
-            <p></p>
-            <div class="btn purp js-close-custom-friends-list">Close</div>
-        `;
+function showFriendsList() {
+	const state = getState();
 
-		const $customFriendsList = makeElement({
-			element: 'div',
-			class: 'menu panel-black js-friends-list uimod-custom-window',
-			content: customFriendsWindowHTML,
-		});
-		document.body.appendChild($customFriendsList);
-
-		// Wire up the buttons
-		Array.from(document.querySelectorAll('.js-whisper-player')).forEach($button => {
-			$button.addEventListener('click', clickEvent => {
-				const name = clickEvent.target.getAttribute('data-player-name');
-				player.whisperPlayer(name);
-			});
-		});
-		Array.from(document.querySelectorAll('.js-party-player')).forEach($button => {
-			$button.addEventListener('click', clickEvent => {
-				const name = clickEvent.target.getAttribute('data-player-name');
-				player.partyPlayer(name);
-			});
-		});
-		Array.from(document.querySelectorAll('.js-unfriend-player')).forEach($button => {
-			$button.addEventListener('click', clickEvent => {
-				const name = clickEvent.target.getAttribute('data-player-name');
-				player.unfriendPlayer(name);
-
-				// Remove the blocked player from the list
-				Array.from(
-					document.querySelectorAll(`.js-friends-list [data-player-name="${name}"]`),
-				).forEach($element => {
-					$element.parentNode.removeChild($element);
-				});
-			});
-		});
-		Array.from(document.querySelectorAll('.js-friend-note')).forEach($element => {
-			$element.addEventListener('change', clickEvent => {
-				const name = clickEvent.target.getAttribute('data-player-name');
-				state.friendNotes[name] = clickEvent.target.value;
-			});
+	if (document.querySelector('.js-friends-list')) {
+		// Don't open the friends list twice.
+		return;
+	}
+	let friendsListHTML = '';
+	Object.keys(state.friendsList)
+		.sort()
+		.forEach(friendName => {
+			friendsListHTML += `
+			<div data-player-name="${friendName}">${friendName}</div>
+			<div class="btn blue js-whisper-player" data-player-name="${friendName}">Whisper</div>
+			<div class="btn blue js-party-player" data-player-name="${friendName}">Party invite</div>
+			<div class="btn orange js-unfriend-player" data-player-name="${friendName}">X</div>
+			<input type="text" class="js-friend-note" data-player-name="${friendName}" value="${state
+				.friendNotes[friendName] || ''}"></input>
+		`;
 		});
 
-		// The close button for our custom UI
-		document.querySelector('.js-close-custom-friends-list').addEventListener('click', () => {
-			const $friendsListWindow = document.querySelector('.js-friends-list');
-			$friendsListWindow.parentNode.removeChild($friendsListWindow);
+	const customFriendsWindowHTML = `
+		<h3 class="textprimary">Friends list</h3>
+		<div class="uimod-friends">${friendsListHTML}</div>
+		<p></p>
+		<div class="btn purp js-close-custom-friends-list">Close</div>
+	`;
+
+	const $customFriendsList = makeElement({
+		element: 'div',
+		class: 'menu panel-black js-friends-list uimod-custom-window',
+		content: customFriendsWindowHTML,
+	});
+	document.body.appendChild($customFriendsList);
+
+	// Wire up the buttons
+	Array.from(document.querySelectorAll('.js-whisper-player')).forEach($button => {
+		$button.addEventListener('click', clickEvent => {
+			const name = clickEvent.target.getAttribute('data-player-name');
+			player.whisperPlayer(name);
 		});
 	});
+	Array.from(document.querySelectorAll('.js-party-player')).forEach($button => {
+		$button.addEventListener('click', clickEvent => {
+			const name = clickEvent.target.getAttribute('data-player-name');
+			player.partyPlayer(name);
+		});
+	});
+	Array.from(document.querySelectorAll('.js-unfriend-player')).forEach($button => {
+		$button.addEventListener('click', clickEvent => {
+			const name = clickEvent.target.getAttribute('data-player-name');
+			player.unfriendPlayer(name);
+
+			// Remove the blocked player from the list
+			Array.from(
+				document.querySelectorAll(`.js-friends-list [data-player-name="${name}"]`),
+			).forEach($element => {
+				$element.parentNode.removeChild($element);
+			});
+		});
+	});
+	Array.from(document.querySelectorAll('.js-friend-note')).forEach($element => {
+		$element.addEventListener('change', clickEvent => {
+			const name = clickEvent.target.getAttribute('data-player-name');
+			state.friendNotes[name] = clickEvent.target.value;
+		});
+	});
+
+	// The close button for our custom UI
+	document
+		.querySelector('.js-close-custom-friends-list')
+		.addEventListener('click', hideFriendsList);
+}
+
+function hideFriendsList() {
+	const $friendsListWindow = document.querySelector('.js-friends-list');
+	$friendsListWindow.parentNode.removeChild($friendsListWindow);
 }
 
 export default {
@@ -95,3 +101,5 @@ export default {
 	description: 'Allows access to your friends list from the top right F icon',
 	run: customFriendsList,
 };
+
+export { showFriendsList, hideFriendsList };

--- a/src/utils/player.js
+++ b/src/utils/player.js
@@ -1,5 +1,7 @@
 import { getState, saveState } from './state';
 import * as chat from './chat';
+import * as friendsList from '../mods/friendsList';
+import * as blockedList from '../mods/blockedPlayerSettings';
 
 function friendPlayer(playerName) {
 	const state = getState();
@@ -11,6 +13,12 @@ function friendPlayer(playerName) {
 	state.friendsList[playerName] = true;
 	chat.addChatMessage(`${playerName} has been added to your friends list.`);
 	saveState();
+
+	// Friends list is currently open, reload it
+	if (document.querySelector('.js-friends-list')) {
+		friendsList.hideFriendsList();
+		friendsList.showFriendsList();
+	}
 }
 
 function unfriendPlayer(playerName) {
@@ -24,6 +32,12 @@ function unfriendPlayer(playerName) {
 	delete state.friendNotes[playerName];
 	chat.addChatMessage(`${playerName} is no longer on your friends list.`);
 	saveState();
+
+	// Friends list is currently open, reload it
+	if (document.querySelector('.js-friends-list')) {
+		friendsList.hideFriendsList();
+		friendsList.showFriendsList();
+	}
 }
 
 // Adds player to block list, to be filtered out of chat
@@ -38,6 +52,12 @@ function blockPlayer(playerName) {
 	chat.filterAllChat();
 	chat.addChatMessage(`${playerName} has been blocked.`);
 	saveState();
+
+	// Blocked list is currently open, reload it
+	if (document.querySelector('.js-blocked-list')) {
+		blockedList.hideBlockedList();
+		blockedList.showBlockedList();
+	}
 }
 
 // Removes player from block list and makes their messages visible again

--- a/src/utils/version.js
+++ b/src/utils/version.js
@@ -4,4 +4,4 @@
 export const BREAKING_VERSION = 1;
 
 // Used for initialization message in chat, and userscript version
-export const VERSION = '1.0.2';
+export const VERSION = '1.0.3';


### PR DESCRIPTION
Update friends/blocked list to show/remove friends from the respective list's ui when the ui is actively open instead of requiring the ui to be manually closed and opened again

- Splitting show/hide logic into their own functions so they can be exported and used in player.js.
- Updating player.js so that if the list uis exist when adding/removing friends/blocked it remakes them after updating the state
- Gave the blocked list its own .js-block-list class instead of using .custom-settings to select it (future-proofing for when additional custom settings are added)